### PR TITLE
Make original author copyright explicit in LICENSE notice.

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,5 +1,5 @@
-Copyright (c) Johann Pardanaud
-Copyright (c) Ministère de l'intérieur
+Copyright (c) 2020 Ministère de l'intérieur
+Copyright (c) 2020 Johann Pardanaud
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENCE
+++ b/LICENCE
@@ -1,3 +1,4 @@
+Copyright (c) Johann Pardanaud
 Copyright (c) Ministère de l'intérieur
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
The original author of the work did not explicitly waived his copyright, so the NOTICE file is misleading in that regard.
This commit adds a copyright mention in the previously mentioned file.