### PR TITLE
Indiquer les informations régionales lors de la création

### DIFF
--- a/src/disallowedReasons.json
+++ b/src/disallowedReasons.json
@@ -1,0 +1,13 @@
+[
+  {
+    "_comment": "JSON file to give Disallow indications. We can indicate a ZipCode (57: Department, 57001: City, 75000: City for example)",
+    "zipcode": "57",
+    "reason": "sport",
+    "hours": {
+      "start": 660, 
+      "end": 1140,
+      "_comment": "660 means 11Am = 11h * 60m"
+    },
+    "message": "Interdiction du vendredi 10 au lundi 13 avril inclus des sorties pour activités sportives individuelles entre 11 h  et 19 h  sur l’ensemble du département de la Moselle"
+  }
+]


### PR DESCRIPTION
En Moselle le week-end du 10 au 13, il est interdit de sortir pour des raisons sportives de 11h à 19h. Cependant il est toujours possible de créer une attestation...

Une fonction a été ajoutée pour savoir en fonction du code postal, de la raison et de l'heure s'il est possible de créer une attestation. Dans le cas contraire afficher un message d'indication.