### PR TITLE
Amélioration de l'auto-complétion

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -116,7 +116,8 @@
             </div>
             
             <div class="form-group">
-                <label for="field-lieunaissance"  id="field-lieunaissance-label">Lieu de naissance</label>
+                <label for="field-lieu
+                            "  id="field-lieunaissance-label">Lieu de naissance</label>
                 <div class="input-group  align-items-center">
                     <input
                         type="text"
@@ -124,6 +125,7 @@
                         id="field-lieunaissance"
                         name="lieunaissance"
                         aria-invalid="true"
+                        autocomplete="off"
                         placeholder="Lyon"
                         required
                     >
@@ -158,7 +160,7 @@
                         class="form-control"
                         id="field-town"
                         name="town"
-                        autocomplete="address-level1"
+                        autocomplete="address-level2"
                         aria-invalid="true"
                         placeholder="Paris"
                         required


### PR DESCRIPTION
La ville d'habitation est maintenant en address-level2 et la ville de naissance ne peut pas être complétée automatiquement, afin de limiter la confusion pour le navigateur.