### PR TITLE
Active l'utilisation du fr-FR au lieu du fr-CA

### DIFF
--- a/src/certificate.js
+++ b/src/certificate.js
@@ -240,7 +240,7 @@ $('#generate-btn').addEventListener('click', async event => {
   const reasons = getAndSaveReasons()
   const pdfBlob = await generatePdf(getProfile(), reasons)
   localStorage.clear()
-  const creationDate = new Date().toLocaleDateString('fr-CA')
+  const creationDate = new Date().toLocaleDateString('fr-FR')
   const creationHour = new Date().toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' }).replace(':', '-')
   downloadBlob(pdfBlob, `attestation-${creationDate}_${creationHour}.pdf`) 
 


### PR DESCRIPTION
Bonjour,

J'ai corrigé ce qui était probablement une typo: l'utilisation du français canadien au lieu du français de France.