### PR TITLE
Ajout du cas n°8 (déménagement) ajouté par la préfecture d'IDF.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -288,7 +288,19 @@
                         value="missions"
                     >
                     <label class="form-radio-label" for="radio-missions">
-                        Déplacements aux seules fins de participer à des missions d’intérêt général sur demande de l’autorité administrative et dans les conditions qu’elle précise&nbsp;.
+                        Déplacements aux seules fins de participer à des missions d’intérêt général sur demande de l’autorité administrative et dans les conditions qu’elle précise&nbsp;;
+                    </label>
+                </div>
+                <div class="form-radio align-items-center">
+                    <input
+                        class="form-check-input"
+                        type="radio"
+                        name="field-reason"
+                        id="radio-demenagement"
+                        value="demenagement"
+                    >
+                    <label class="form-radio-label" for="radio-demenagement">
+                        Déplacements liés à un déménagement résultant d’un changement de domicile et déplacements indispensables à l’acquisition ou à la location d’un bien immobilier insusceptibles d’être différés&nbsp;.
                     </label>
                 </div>
             </fieldset>


### PR DESCRIPTION
Ce cas n°8 a été ajouté par la [préfecture d'Ile de France](https://www.prefectures-regions.gouv.fr/ile-de-france/Region-et-institutions/L-action-de-l-Etat/Amenagement-du-territoire-transport-et-environnement/Les-transports-du-quotidien/Deconfinement-les-attestations-pour-se-deplacer-dans-les-transports-en-commun-en-heures-de-pointe).

Ce cas a déjà été intégré sur la branche `master` pour l'attestation de déplacement de plus de 100km, mais ce n'a pas été fait pour l'attestation de déplacements en Ile de France.

J'ai donc reproduit la PR #131 sur la branche `attestation-deplacement-idf-covid-19`.